### PR TITLE
Restrict BigBrother authorization page

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -131,6 +131,39 @@ foreach ($settings as $setting) {
 $modx->log(modX::LOG_LEVEL_INFO,'Packaged in '.count($settings).' system settings.'); flush();
 unset($settings,$setting,$attributes);
 
+/**
+ * Access Policy Templates & Access Policies
+ */
+$templates = include $sources['data'].'transport.policy_templates.php';
+$attributes = [
+    xPDOTransport::PRESERVE_KEYS => true,
+    xPDOTransport::UNIQUE_KEY => ['name'],
+    xPDOTransport::UPDATE_OBJECT => true,
+    xPDOTransport::RELATED_OBJECTS => true,
+    xPDOTransport::RELATED_OBJECT_ATTRIBUTES => [
+        'Permissions' => [
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UPDATE_OBJECT => true,
+            xPDOTransport::UNIQUE_KEY => ['template','name'],
+        ],
+        'Policies' => [
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UPDATE_OBJECT => true,
+            xPDOTransport::UNIQUE_KEY => ['template','name'],
+        ],
+    ]
+];
+if (is_array($templates)) {
+    foreach ($templates as $template) {
+        $vehicle = $builder->createVehicle($template,$attributes);
+        $builder->putVehicle($vehicle);
+    }
+    $modx->log(\modX::LOG_LEVEL_INFO,'Packaged in '.count($templates).' Access Policy Templates.'); flush();
+} else {
+    $modx->log(\modX::LOG_LEVEL_ERROR,'Could not package in Access Policy Templates.');
+}
+unset ($templates, $template, $attributes);
+
 /* Load Dashboard Widgets */
 $modx->log(modX::LOG_LEVEL_INFO,'Packaging in Dashboard Widgets...');
 $widgets = include $sources['data'].'transport.dashboard_widgets.php';

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -94,46 +94,10 @@ $builder->package->put(
 );
 $modx->log(modX::LOG_LEVEL_INFO,'Packaged in core and requirements validator.'); flush();
 
-$builder->package->put(
-    [
-        'source' => $sources['source_assets'],
-        'target' => "return MODX_ASSETS_PATH . 'components/';",
-    ],
-    [
-        'vehicle_class' => 'xPDOFileVehicle',
-        'resolve' => [
-            [
-                'type' => 'php',
-                'source' => $sources['resolvers'] . 'removeoldfiles.resolver.php',
-            ],
-            [
-                'type' => 'php',
-                'source' => $sources['resolvers'] . 'dependencies.resolver.php',
-            ]
-        ],
-    ]
-);
-$modx->log(modX::LOG_LEVEL_INFO,'Packaged in assets and removeoldfiles resolver.'); flush();
-
-/* Load system settings */
-$modx->log(modX::LOG_LEVEL_INFO,'Packaging in System Settings...');
-$settings = include $sources['data'].'transport.settings.php';
-if (empty($settings)) $modx->log(modX::LOG_LEVEL_ERROR,'Could not package in settings.');
-$attributes= array(
-    xPDOTransport::UNIQUE_KEY => 'key',
-    xPDOTransport::PRESERVE_KEYS => true,
-    xPDOTransport::UPDATE_OBJECT => false,
-);
-foreach ($settings as $setting) {
-    $vehicle = $builder->createVehicle($setting,$attributes);
-    $builder->putVehicle($vehicle);
-}
-$modx->log(modX::LOG_LEVEL_INFO,'Packaged in '.count($settings).' system settings.'); flush();
-unset($settings,$setting,$attributes);
-
 /**
  * Access Policy Templates & Access Policies
  */
+$modx->log(modX::LOG_LEVEL_INFO,'Packaging in Access Policy Templates...');
 $templates = include $sources['data'].'transport.policy_templates.php';
 $attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
@@ -163,6 +127,49 @@ if (is_array($templates)) {
     $modx->log(\modX::LOG_LEVEL_ERROR,'Could not package in Access Policy Templates.');
 }
 unset ($templates, $template, $attributes);
+
+
+$builder->package->put(
+    [
+        'source' => $sources['source_assets'],
+        'target' => "return MODX_ASSETS_PATH . 'components/';",
+    ],
+    [
+        'vehicle_class' => 'xPDOFileVehicle',
+        'resolve' => [
+            [
+                'type' => 'php',
+                'source' => $sources['resolvers'] . 'removeoldfiles.resolver.php',
+            ],
+            [
+                'type' => 'php',
+                'source' => $sources['resolvers'] . 'dependencies.resolver.php',
+            ],
+            [
+                'type' => 'php',
+                'source' => $sources['resolvers'] . 'policies.resolver.php',
+            ]
+        ],
+    ]
+);
+$modx->log(modX::LOG_LEVEL_INFO,'Packaged in assets and removeoldfiles resolver.'); flush();
+
+/* Load system settings */
+$modx->log(modX::LOG_LEVEL_INFO,'Packaging in System Settings...');
+$settings = include $sources['data'].'transport.settings.php';
+if (empty($settings)) $modx->log(modX::LOG_LEVEL_ERROR,'Could not package in settings.');
+$attributes= array(
+    xPDOTransport::UNIQUE_KEY => 'key',
+    xPDOTransport::PRESERVE_KEYS => true,
+    xPDOTransport::UPDATE_OBJECT => false,
+);
+foreach ($settings as $setting) {
+    $vehicle = $builder->createVehicle($setting,$attributes);
+    $builder->putVehicle($vehicle);
+}
+$modx->log(modX::LOG_LEVEL_INFO,'Packaged in '.count($settings).' system settings.'); flush();
+unset($settings,$setting,$attributes);
+
 
 /* Load Dashboard Widgets */
 $modx->log(modX::LOG_LEVEL_INFO,'Packaging in Dashboard Widgets...');

--- a/_build/data/permissions/bigbrothertemplate.permissions.php
+++ b/_build/data/permissions/bigbrothertemplate.permissions.php
@@ -2,10 +2,10 @@
 
 /** @var \modX $modx */
 $permissions = [];
-$permissions[] = $modx->newObject('modAccessPermission',array(
+$permissions[] = $modx->newObject('modAccessPermission',[
     'name' => 'bigbrother_authorize',
     'description' => 'bigbrother.permission.authorize',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/permissions/bigbrothertemplate.permissions.php
+++ b/_build/data/permissions/bigbrothertemplate.permissions.php
@@ -1,0 +1,11 @@
+<?php
+
+/** @var \modX $modx */
+$permissions = [];
+$permissions[] = $modx->newObject('modAccessPermission',array(
+    'name' => 'bigbrother_authorize',
+    'description' => 'bigbrother.permission.authorize',
+    'value' => true,
+));
+
+return $permissions;

--- a/_build/data/policies/bigbrothertemplate.policies.php
+++ b/_build/data/policies/bigbrothertemplate.policies.php
@@ -1,0 +1,15 @@
+<?php
+/** @var \modX $modx */
+
+$policies = [];
+$policies[1]= $modx->newObject('modAccessPolicy');
+$policies[1]->fromArray([
+    'name' => 'BigBrother Admin',
+    'description' => 'Access Policy for BigBrother that gives access to the authorization manager page. Overwritten on upgrade.',
+    'parent' => 0,
+    'class' => '',
+    'lexicon' => 'bigbrother:permissions',
+    'data' => '{"bigbrother_authorize":true}',
+], '', true, true);
+
+return $policies;

--- a/_build/data/transport.policy_templates.php
+++ b/_build/data/transport.policy_templates.php
@@ -1,0 +1,28 @@
+<?php
+
+/** @var \modX $modx */
+$templates = [];
+$templates[1]= $modx->newObject('modAccessPolicyTemplate');
+$templates[1]->fromArray([
+    'id' => 1,
+    'name' => 'BigBrotherTemplate',
+    'description' => 'Policy Template for access to the BigBrother authorization page.',
+    'lexicon' => 'bigbrother:permissions',
+    'template_group' => 1,
+]);
+
+$permissions = include dirname(__FILE__).'/permissions/bigbrothertemplate.permissions.php';
+if (is_array($permissions)) {
+    $templates[1]->addMany($permissions);
+} else {
+    $modx->log(modX::LOG_LEVEL_ERROR,'Could not load BigBrotherTemplate Permissions.');
+}
+
+$policies = include dirname(__FILE__).'/policies/bigbrothertemplate.policies.php';
+if (is_array($policies)) {
+    $templates[1]->addMany($policies);
+} else {
+    $modx->log(modX::LOG_LEVEL_ERROR,'Could not load BigBrotherTemplate Policies.');
+}
+
+return $templates;

--- a/_build/resolvers/policies.resolver.php
+++ b/_build/resolvers/policies.resolver.php
@@ -1,0 +1,66 @@
+<?php
+
+/** @var modX $modx */
+$modx =& $object->xpdo;
+
+switch ($options[xPDOTransport::PACKAGE_ACTION]) {
+    case xPDOTransport::ACTION_INSTALL:
+    case xPDOTransport::ACTION_UPGRADE:
+        $modx->log(xPDO::LOG_LEVEL_INFO, 'Installing User Group access to the BigBrother Admin Policy...');
+
+        /* assign policy to admin group */
+        $policy = $modx->getObject('modAccessPolicy', ['name' => 'BigBrother Admin']);
+        $adminGroup = $modx->getObject('modUserGroup', ['name' => 'Administrator']);
+        if ($policy && $adminGroup) {
+            /**
+             * Check if we need to apply any default accesses
+             */
+            $access = $modx->getObject('modAccessContext', [
+                'target' => 'mgr',
+                'principal_class' => 'modUserGroup',
+                'principal' => $adminGroup->get('id'),
+                'authority' => 9999,
+                'policy' => $policy->get('id'),
+            ]);
+            if (!$access) {
+                $modx->log(modX::LOG_LEVEL_WARN, "Administrator user group does not yet have access to the BigBrother policy, so let's add it!.");
+                /**
+                 * Add the context access to the admin user group
+                 */
+                $hasMgrAccess = $modx->getCount('modAccessContext', [
+                    'target' => 'mgr',
+                    'principal_class' => 'modUserGroup',
+                    'principal' => $adminGroup->get('id'),
+                ]);
+
+                $access = $modx->newObject('modAccessContext');
+                $access->fromArray([
+                    'target' => 'mgr',
+                    'principal_class' => 'modUserGroup',
+                    'principal' => $adminGroup->get('id'),
+                    'authority' => 9999,
+                    'policy' => $policy->get('id'),
+                ]);
+                if ($access->save()) {
+                    $modx->log(modX::LOG_LEVEL_INFO, '- Added a Context Policy for user group' . $adminGroup->get('name') . ' for full BigBrother access.');
+                }
+
+            }
+            else {
+                $modx->log(modX::LOG_LEVEL_INFO, 'As the Administrator user group already has access to the BigBrother Policy, we will not set up any permissions right now.');
+            }
+        }
+
+        // flush permissions
+        $ctxQuery = $modx->newQuery('modContext');
+        $ctxQuery->select($modx->getSelectColumns('modContext', '', '', ['key']));
+        if ($ctxQuery->prepare() && $ctxQuery->stmt->execute()) {
+            $contexts = $ctxQuery->stmt->fetchAll(PDO::FETCH_COLUMN);
+            if ($contexts) {
+                $serialized = serialize($contexts);
+                $modx->exec("UPDATE {$modx->getTableName('modUser')} SET {$modx->escape('session_stale')} = {$modx->quote($serialized)}");
+            }
+        }
+        break;
+}
+return true;

--- a/core/components/bigbrother/controllers/authorize.class.php
+++ b/core/components/bigbrother/controllers/authorize.class.php
@@ -27,6 +27,11 @@ class BigbrotherAuthorizeManagerController extends modExtraManagerController {
         return ['bigbrother:default'];
     }
 
+    public function checkPermissions(): bool
+    {
+        return $this->modx->context->checkPolicy('bigbrother_authorize');
+    }
+
     public function initialize()
     {
         $this->bigbrother = new BigBrother($this->modx);

--- a/core/components/bigbrother/elements/widgets/abstract.class.php
+++ b/core/components/bigbrother/elements/widgets/abstract.class.php
@@ -146,12 +146,20 @@ HTML;
     {
         $property = $this->getGA4Property($propertyId);
 
+        // Only display the authorize link if the user has the correct permissions
+        $authorizeLink = '';
+        if ($this->modx->context->checkPolicy('bigbrother_authorize')) {
+            $authorizeLink = <<<HTML
+<a href="{$this->bigbrother->getAuthorizeUrl()}" title="{$this->modx->lexicon('bigbrother.authorization')}" class="authorize-link"><i class="icon icon-cog"></i></a>
+HTML;
+        }
+
         return <<<HTML
 <div class="bigbrother-widget-title">
     <div>
         <span>{$this->modx->lexicon('bigbrother.widget_title', ['property_name' => $property->getDisplayName()])}</span>
         <span class="property-id">{$propertyId}</span>
-        <a href="{$this->bigbrother->getAuthorizeUrl()}" title="{$this->modx->lexicon('bigbrother.authorization')}" class="authorize-link"><i class="icon icon-cog"></i></a>
+        {$authorizeLink}
     </div>
     <div class="period-wrapper">
         <span id="bb-title-period" class="bigbrother-title-period">{$this->modx->lexicon('bigbrother.loading')}</span>

--- a/core/components/bigbrother/lexicon/en/permissions.inc.php
+++ b/core/components/bigbrother/lexicon/en/permissions.inc.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Permissions English Lexicon Entries for BigBrother
+ *
+ * @package bigbrother
+ * @subpackage lexicon
+ *
+ */
+$_lang['bigbrother.permission.authorize'] = 'Allows loading the BigBrother authorization manager page.';


### PR DESCRIPTION
This feature adds a policy template, an access policy, an authorization permission and adds the policy to the Administrator user group automatically on install/upgrade.
Any user who does not have the bigbrother_authorize permission will not be able to load the BigBrother authorization page and the icon/link won't appear on the dashboard widgets.